### PR TITLE
Ws/min 2309 disable links on demand through url query

### DIFF
--- a/lib/graphiti/query.rb
+++ b/lib/graphiti/query.rb
@@ -23,6 +23,8 @@ module Graphiti
 
     def links?
       return false if [:json, :xml, "json", "xml"].include?(params[:format])
+      return false if [false, "false"].include?(@params[:links])
+
       if Graphiti.config.links_on_demand
         [true, "true"].include?(@params[:links])
       else

--- a/lib/graphiti/query.rb
+++ b/lib/graphiti/query.rb
@@ -33,6 +33,8 @@ module Graphiti
     end
 
     def pagination_links?
+      return false if [false, "false"].include?(@params[:pagination_links])
+
       if Graphiti.config.pagination_links_on_demand
         [true, "true"].include?(@params[:pagination_links])
       else

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -914,6 +914,22 @@ RSpec.describe Graphiti::Query do
       it { is_expected.to eq(false) }
     end
 
+    context "when requested as string 'false'" do
+      before do
+        params[:links] = "false"
+      end
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "when requested as boolean false" do
+      before do
+        params[:links] = false
+      end
+
+      it { is_expected.to eq(false) }
+    end
+
     context "when links_on_demand" do
       around do |e|
         original = Graphiti.config.links_on_demand
@@ -926,7 +942,7 @@ RSpec.describe Graphiti::Query do
       end
 
       context "and requested" do
-        context "as string" do
+        context "as string 'true'" do
           before do
             params[:links] = "true"
           end
@@ -934,7 +950,7 @@ RSpec.describe Graphiti::Query do
           it { is_expected.to eq(true) }
         end
 
-        context "as boolean" do
+        context "as boolean true" do
           before do
             params[:links] = true
           end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -893,6 +893,26 @@ RSpec.describe Graphiti::Query do
     end
   end
 
+  describe "#pagination_links?" do
+    subject { instance.pagination_links? }
+
+    context "when requested as string 'false'" do
+      before do
+        params[:pagination_links] = "false"
+      end
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "when requested as boolean false" do
+      before do
+        params[:pagination_links] = false
+      end
+
+      it { is_expected.to eq(false) }
+    end
+  end
+
   describe "#links?" do
     subject { instance.links? }
 

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -936,7 +936,7 @@ RSpec.describe Graphiti::Query do
 
         context "as boolean" do
           before do
-            params[:links] = "true"
+            params[:links] = true
           end
 
           it { is_expected.to eq(true) }


### PR DESCRIPTION
Pagination links have to be processed and they perform `count` queries. We found out that removing these pagination links greatly improved the performance of our system. Mostly because it is very expensive to do counts on certain tables.

This change allows the API clients to remove the links and pagination links with a query parameter:

```json
api.example.com/resource?links=false&pagination_links=false
```